### PR TITLE
add purchase_hide_report_print_menu

### DIFF
--- a/purchase_hide_report_print_menu/README.rst
+++ b/purchase_hide_report_print_menu/README.rst
@@ -1,0 +1,49 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+================================
+Purchase Hide Report Print Menu
+================================
+
+This module hide print report 'Request for Quotation' in purchase order menu.
+ 
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/142/8.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/akretion/odoo-usability/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed `feedback
+<https://github.com/akretion/
+odoo-usability/issues/new?body=module:%20
+purchase_hide_report_print_menu%0Aversion:%20
+8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+ 
+Credits
+=======
+ 
+Contributors
+------------
+ 
+* Chafique Delli chafique.delli@akretion.com
+ 
+Maintainer
+----------
+ 
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its  widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/purchase_hide_report_print_menu/__init__.py
+++ b/purchase_hide_report_print_menu/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 Chafique DELLI @ Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import purchase

--- a/purchase_hide_report_print_menu/__openerp__.py
+++ b/purchase_hide_report_print_menu/__openerp__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# © 2016 Chafique DELLI @ Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Purchase Hide Report Print Menu',
+    'summary': "Hide print report 'Request for Quotation' "
+    "in purchase order menu",
+    'version': '8.0.1.0.0',
+    'category': 'Purchase Management',
+    'website': 'http://akretion.com',
+    'author': 'Akretion, Odoo Community Association (OCA)',
+    'license': 'AGPL-3',
+    'application': False,
+    'installable': True,
+    'depends': [
+        'purchase',
+    ],
+    'data': [
+        'purchase_view.xml',
+    ]
+}

--- a/purchase_hide_report_print_menu/purchase.py
+++ b/purchase_hide_report_print_menu/purchase.py
@@ -11,18 +11,13 @@ class PurchaseOrder(models.Model):
     @api.model
     def fields_view_get(self, view_id=None, view_type='form', toolbar=False,
                         submenu=False):
-        context = self._context
         res = super(PurchaseOrder, self).fields_view_get(
             view_id=view_id, view_type=view_type, toolbar=toolbar,
             submenu=submenu)
-        if ('purchase_order' in context and 'toolbar' in res and
-                'print' in res['toolbar']):
+        if self._context.get('purchase_order', False):
             report_purchase_quotation = self.env.ref(
                 'purchase.report_purchase_quotation')
-            list_print_submenu_to_hide = []
-            for print_submenu in res['toolbar']['print']:
-                if print_submenu['id'] in [report_purchase_quotation.id]:
-                    list_print_submenu_to_hide.append(print_submenu)
-            for print_submenu_to_hide in list_print_submenu_to_hide:
-                res['toolbar']['print'].remove(print_submenu_to_hide)
+            for print_submenu in res.get('toolbar', {}).get('print', []):
+                if print_submenu['id'] == report_purchase_quotation.id:
+                    res['toolbar']['print'].remove(print_submenu)
         return res

--- a/purchase_hide_report_print_menu/purchase.py
+++ b/purchase_hide_report_print_menu/purchase.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# © 2016 Chafique DELLI @ Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    def fields_view_get(self, cr, uid, view_id=None, view_type='form',
+                        context=None, toolbar=False, submenu=False):
+        if context is None:
+            context = {}
+        res = super(PurchaseOrder, self).fields_view_get(
+            cr, uid, view_id=view_id, view_type=view_type, context=context,
+            toolbar=toolbar, submenu=submenu)
+        if ('purchase_order' in context and 'toolbar' in res and
+                'print' in res['toolbar']):
+            model_data_obj = self.pool['ir.model.data']
+            report_purchase_quotation_id = model_data_obj.xmlid_to_res_id(
+                cr, uid, 'purchase.report_purchase_quotation',
+                raise_if_not_found=True)
+            list_print_submenu_to_hide = []
+            for print_submenu in res['toolbar']['print']:
+                if print_submenu['id'] in [report_purchase_quotation_id]:
+                    list_print_submenu_to_hide.append(print_submenu)
+            for print_submenu_to_hide in list_print_submenu_to_hide:
+                res['toolbar']['print'].remove(print_submenu_to_hide)
+        return res

--- a/purchase_hide_report_print_menu/purchase.py
+++ b/purchase_hide_report_print_menu/purchase.py
@@ -2,28 +2,26 @@
 # © 2016 Chafique DELLI @ Akretion
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openerp import models
+from openerp import models, api
 
 
 class PurchaseOrder(models.Model):
     _inherit = 'purchase.order'
 
-    def fields_view_get(self, cr, uid, view_id=None, view_type='form',
-                        context=None, toolbar=False, submenu=False):
-        if context is None:
-            context = {}
+    @api.model
+    def fields_view_get(self, view_id=None, view_type='form', toolbar=False,
+                        submenu=False):
+        context = self._context
         res = super(PurchaseOrder, self).fields_view_get(
-            cr, uid, view_id=view_id, view_type=view_type, context=context,
-            toolbar=toolbar, submenu=submenu)
+            view_id=view_id, view_type=view_type, toolbar=toolbar,
+            submenu=submenu)
         if ('purchase_order' in context and 'toolbar' in res and
                 'print' in res['toolbar']):
-            model_data_obj = self.pool['ir.model.data']
-            report_purchase_quotation_id = model_data_obj.xmlid_to_res_id(
-                cr, uid, 'purchase.report_purchase_quotation',
-                raise_if_not_found=True)
+            report_purchase_quotation = self.env.ref(
+                'purchase.report_purchase_quotation')
             list_print_submenu_to_hide = []
             for print_submenu in res['toolbar']['print']:
-                if print_submenu['id'] in [report_purchase_quotation_id]:
+                if print_submenu['id'] in [report_purchase_quotation.id]:
                     list_print_submenu_to_hide.append(print_submenu)
             for print_submenu_to_hide in list_print_submenu_to_hide:
                 res['toolbar']['print'].remove(print_submenu_to_hide)

--- a/purchase_hide_report_print_menu/purchase_view.xml
+++ b/purchase_hide_report_print_menu/purchase_view.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<openerp>
+<data>
+
+<record model="ir.actions.act_window" id="purchase.purchase_form_action">
+    <field name="context">{'purchase_order': True}</field>
+</record>
+
+</data>
+</openerp>


### PR DESCRIPTION
Par défaut dans le menu 'Achats/Bon de commande', on a dans le menu 'Imprimer' les choix 'Demande de prix' et 'Bon de commande'.Imprimer une demande de prix lorsqu'on est sur des commandes d'achat validées, n'est pas très logique. 
Ce module cache donc la possibilité d'imprimer un rapport 'Demande de prix' lorsqu'on est dans le menu 'Achats/Bon de commande'.
