### PR TITLE
[8.0] Remove stored field product_supplier_code on stock.move

### DIFF
--- a/stock_usability/stock.py
+++ b/stock_usability/stock.py
@@ -77,30 +77,6 @@ class StockWarehouseOrderpoint(models.Model):
 class StockMove(models.Model):
     _inherit = 'stock.move'
 
-    product_supplier_code = fields.Char(
-        string='Supplier Code', compute='_compute_supplier_code',
-        store=True, readonly=True,
-        help="Supplier product code if Partner is the supplier")
-
-# It seems that it is not necessary any more to
-# have the digits= on these 2 fields to fix the bug
-# https://github.com/odoo/odoo/pull/10038
-#    reserved_availability = fields.Float(
-#        digits=dp.get_precision('Product Unit of Measure'))
-#    availability = fields.Float(
-#        digits=dp.get_precision('Product Unit of Measure'))
-
-    @api.multi
-    @api.depends('product_id', 'picking_id.partner_id')
-    def _compute_supplier_code(self):
-        for rec in self:
-            supplier_code = False
-            if rec.picking_id.partner_id and rec.product_id:
-                for supplier_info in rec.product_id.seller_ids:
-                    if supplier_info.name == rec.picking_id.partner_id:
-                        supplier_code = supplier_info.product_code
-            rec.product_supplier_code = supplier_code
-
     def name_get(self, cr, uid, ids, context=None):
         '''name_get of stock_move is important for the reservation of the
         quants: so want to add the name of the customer and the expected date

--- a/stock_usability/stock_view.xml
+++ b/stock_usability/stock_view.xml
@@ -161,9 +161,6 @@
                 icon="STOCK_UNDO" groups="stock.group_stock_user"
                 states="confirmed,assigned"/>
         </field>
-        <field name="product_id" position="after">
-            <field name="product_supplier_code"/>
-        </field>
     </field>
 </record>
 


### PR DESCRIPTION
 because it takes a very very long time to compute on existing large DB and it is not needed by everybody.
@bealdav If you really think we should keep this field in stock_usability (and not in another usability module), please explain your arguments here. Remember that stock_usability is a module designed to be installed by everybody !