### PR TITLE
[FIX] change button name bug

### DIFF
--- a/account_usability/account_view.xml
+++ b/account_usability/account_view.xml
@@ -276,9 +276,10 @@ module -->
             </button>
         </button>
         <button name="%(account.action_account_moves_all_tree)d" position="attributes">
-            <attribute name="type">object</attribute>
-            <attribute name="name">show_receivable_account</attribute>
-            <attribute name="attrs">{'invisible': [('customer', '=', False)]}</attribute>
+            <attribute name="invisible">True</attribute>
+        </button>
+        <button name="%(account.action_account_moves_all_tree)d" position="after">
+            <button type="object" class="oe_stat_button" name="show_receivable_account" icon="fa-list" attrs="{'invisible': [('customer', '=', False)]}"/>
         </button>
         <field name="journal_item_count" position="attributes">
             <attribute name="string">Receivable Account</attribute>


### PR DESCRIPTION
This PR is the fix this  bug : (button can't be located in other view if we change it name)

> `D\xe9tails de l'erreur :
L'\xe9l\xe9ment '<button name="248">' ne peut \xeatre localis\xe9 dans la vue parente
Contexte de l'erreur :
Vue `usability.res.partner.journal.items.button`
[view_id: 1984, xml_id: n/a, model: res.partner, parent_id: 1942]  " while parsing /workspace/parts/odoo-usability/account_usability/account_view.xml:265, near
````xml
<record id="partner_view_button_journal_item_count" model="ir.ui.view">
    <field name="name">usability.res.partner.journal.items.button</field>
    <field name="model">res.partner</field>
    <field name="inherit_id" ref="account.partner_view_button_journal_item_count"/>
    <field name="arch" type="xml">
        <data><button name="%(account.action_account_moves_all_tree)d" position="after">
            <button name="show_payable_account" type="object" attrs="{'invisible': [('supplier', '=', False)]}" icon="fa-list" class="oe_stat_button">
                <field string="Payable Account" name="payable_journal_item_count" widget="statinfo"/>
            </button>
        </button>
        <button name="%(account.action_account_moves_all_tree)d" position="attributes">
            <attribute name="type">object</attribute>
            <attribute name="name">show_receivable_account</attribute>
            <attribute name="attrs">{'invisible': [('customer', '=', False)]}</attribute>
        </button>
        <field name="journal_item_count" position="attributes">
            <attribute name="string">Receivable Account</attribute>
        </field>
    </data></field>
</record>
```