### PR TITLE
[FIX] Remove hard-coded oe_title class width

### DIFF
--- a/base_usability/views/partner_view.xml
+++ b/base_usability/views/partner_view.xml
@@ -12,10 +12,6 @@
     <field name="model">res.partner</field>
     <field name="inherit_id" ref="base.view_partner_form"/>
     <field name="arch" type="xml">
-        <!-- Wider 'name' field -->
-        <xpath expr="//sheet/div[hasclass('oe_title')]" position="attributes">
-            <attribute name="style">width: 650px;</attribute>
-        </xpath>
         <xpath expr="//field[@name='child_ids']/form//field[@name='email']" position="attributes">
             <attribute name="widget">email</attribute>
         </xpath>


### PR DESCRIPTION
I've noticed that this hard-coded `width: 650px` was more than 5 years old.

Now some specific CSS modules exist like OCA `web_responsive` or Openworx `backend_theme` that are doing this kind of job in a much better way... And this kind of hard-code is blocking them, so it looks better to remove it and use these modules for CSS purpose.