### PR TITLE
[IMP] Remove 'translate=False' for res.partner.category's name

### DIFF
--- a/base_usability/models/partner.py
+++ b/base_usability/models/partner.py
@@ -124,12 +124,6 @@ class ResPartner(models.Model):
         return res
 
 
-class ResPartnerCategory(models.Model):
-    _inherit = 'res.partner.category'
-
-    name = fields.Char(translate=False)
-
-
 class ResPartnerBank(models.Model):
     _inherit = 'res.partner.bank'
 


### PR DESCRIPTION
Hi,

I needed `res.partner.category`'s name to be **translatable** for my personal _["Band Booking project"](https://github.com/clementmbr/band-booking)_ and I thought that it could be in fact more common to need this field translatable rather than not translatable... So I made this PR.

If other people agree, let's merge it! :)

CC @alexis-via @bealdav @rvalyi 
