### PR TITLE
[FIX] Remove hard-coded width on product's title

### DIFF
--- a/product_usability/views/product_template_view.xml
+++ b/product_usability/views/product_template_view.xml
@@ -16,11 +16,6 @@
             <field name="standard_price" class="oe_inline" position="after">
                 <button name="show_product_price_history" class="oe_inline oe_link" type="object" string="Show History" context="{'active_id': active_id}"/>
             </field>
-            <!-- Don't make it too big, othesize computers with small resolutions
-            will see the product name + image under the block of buttons -->
-            <div class="oe_title" position="attributes">
-                <attribute name="style">width: 650px;</attribute>
-            </div>
         </field>
     </record>
 


### PR DESCRIPTION
Same idea as #123 but for product_usability 
It helps avoiding these kind of horrors using openworx backend_theme_v12 :
![image](https://user-images.githubusercontent.com/31664455/96658072-12c65f80-131a-11eb-8855-b0372708d529.png)
Cc @rvalyi @bealdav , if you enjoyed #123...