### PR TITLE
[14.0][MIG] sale_no_optional_product, sale_no_preview_button: migration to 14.0

### DIFF
--- a/sale_no_optional_product/__manifest__.py
+++ b/sale_no_optional_product/__manifest__.py
@@ -5,19 +5,20 @@
 {
     "name": "Sale no optional product",
     "summary": "Hide optional product",
-    "version": "12.0.1.0.0",
+    "version": "14.0.1.0.0",
     "category": "Usability",
     "website": "www.akretion.com",
     "author": " Akretion",
     "license": "AGPL-3",
     "application": False,
-    "installable": False,
+    "installable": True,
     "external_dependencies": {
         "python": [],
         "bin": [],
     },
     "depends": [
         "sale_management",
+        "sale_product_configurator"
     ],
     "data": [
         "views/product_template_view.xml",

--- a/sale_no_preview_button/__manifest__.py
+++ b/sale_no_preview_button/__manifest__.py
@@ -5,13 +5,13 @@
 {
     "name": "Sale no preview button",
     "summary": "Hide 'preview' from sale",
-    "version": "12.0.1.0.0",
+    "version": "14.0.1.0.0",
     "category": "Usabability",
     "website": "www.akretion.com",
     "author": " Akretion",
     "license": "AGPL-3",
     "application": False,
-    "installable": False,
+    "installable": True,
     "external_dependencies": {
         "python": [],
         "bin": [],


### PR DESCRIPTION
Discussion:

sale_no_optional_product

on product.template we have 

        <group name="options" position="attributes">
            <attribute name="attrs">{'invisible': []}</attribute>
        </group>

however, this is no longer part of sale, instead it is part of sale_product_configurator, which can be activated ("Product Configurator" in general settings -> sale)