### PR TITLE
[FIX] report/invoice_report.xml in account_usability

### DIFF
--- a/account_usability/report/invoice_report.xml
+++ b/account_usability/report/invoice_report.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template id="report_invoice_document" inherit_id="account.report_invoice_document">
-    <xpath expr="//div[@name='origin']/p" position="replace">
+    <xpath expr="//p[@t-field='o.origin']" position="replace">
         <p class="m-0" t-field="o.sale_dates"/>
     </xpath>
 </template>


### PR DESCRIPTION
Fix the error: The element '<xpath expr="//div[@name='origin']/p" position="replace">'  cannot be located in the parent view account.report_invoice_document.