### PR TITLE
[IMP] add a button on kanban to open child partner

### DIFF
--- a/base_usability/__manifest__.py
+++ b/base_usability/__manifest__.py
@@ -10,7 +10,7 @@
     'summary': 'Better usability in base module',
     'author': 'Akretion',
     'website': 'http://www.akretion.com',
-    'depends': ['base'],
+    'depends': ['base', 'contacts'],
     'data': [
         'security/group.xml',
         'security/ir.model.access.csv',

--- a/base_usability/views/res_partner.xml
+++ b/base_usability/views/res_partner.xml
@@ -20,6 +20,15 @@
         <div attrs="{'invisible': [('same_vat_partner_id', '=', False)]}" position="attributes">
             <attribute name="class">alert alert-warning</attribute>
         </div>
+        <!-- Add a kanban button to open child partner -->
+        <xpath expr="//field[@name='child_ids']//kanban/templates/t/div" position="inside">
+            <div class="o_dropdown_kanban">
+                <a class="btn" role="button" title="Open"
+                   t-att-href="'/web#id=' + record.id.raw_value + '&amp;action=%(contacts.action_contacts)d' + '&amp;menu_id=%(contacts.menu_contacts)d' + '&amp;view_type=form&amp;cids=1&amp;model=res.partner'">
+                    <span class="fa fa-external-link" />
+                </a>
+            </div>
+        </xpath>
     </field>
 </record>
 


### PR DESCRIPTION
Add a subtle external link button on child partner kanban to open it completely :
![image](https://user-images.githubusercontent.com/31664455/120284052-237d8180-c2bc-11eb-88aa-aef5eef00d20.png)

The breadcrumb is not very consistent. Sometimes it adds an intermediary "Contacts" sometimes it reset to main "Contacts" action :
![image](https://user-images.githubusercontent.com/31664455/120284631-bc140180-c2bc-11eb-974f-bdb4225101d4.png)
![image](https://user-images.githubusercontent.com/31664455/120284706-d2ba5880-c2bc-11eb-9c9d-bbaa6ef810f3.png)

... But it is still much less pain than to be blocked when you only want to open quickly the child and you can't.
cc @rvalyi @alexis-via 
