### PR TITLE
purchase_usability: remove unnecessary field `delivery_partner_id`

### DIFF
--- a/purchase_stock_usability/models/purchase.py
+++ b/purchase_stock_usability/models/purchase.py
@@ -10,17 +10,3 @@ class PurchaseOrder(models.Model):
 
     picking_type_id = fields.Many2one(tracking=True)
     incoterm_id = fields.Many2one(tracking=True)
-
-    # inherit compute method of the field delivery_partner_id
-    # defined in purchase_usability
-    @api.depends('dest_address_id', 'picking_type_id')
-    def _compute_delivery_partner_id(self):
-        for o in self:
-            delivery_partner_id = False
-            if o.dest_address_id:
-                delivery_partner_id = o.dest_address_id
-            elif (
-                    o.picking_type_id.warehouse_id and
-                    o.picking_type_id.warehouse_id.partner_id):
-                delivery_partner_id = o.picking_type_id.warehouse_id.partner_id
-            o.delivery_partner_id = delivery_partner_id

--- a/purchase_usability/models/purchase_order.py
+++ b/purchase_usability/models/purchase_order.py
@@ -14,15 +14,6 @@ class PurchaseOrder(models.Model):
     payment_term_id = fields.Many2one(tracking=True)
     fiscal_position_id = fields.Many2one(tracking=True)
     partner_ref = fields.Char(tracking=True)
-    # the field 'delivery_partner_id' is used in report
-    # the compute method of that field is inherited in purchase_stock_usability
-    delivery_partner_id = fields.Many2one(
-        'res.partner', compute='_compute_delivery_partner_id')
-
-    @api.depends('dest_address_id')
-    def _compute_delivery_partner_id(self):
-        for order in self:
-            order.delivery_partner_id = order.dest_address_id
 
     def print_order(self):
         report = self.env.ref('purchase.action_report_purchase_order')


### PR DESCRIPTION
I understood this field was aimed to be used in PO reports, but there is not such report's inherited views in the modules.
Moreover in native module **purchase_stock** there is already a condition displaying the warehouse's partner_id as Shipping Address (as expected) : 
https://github.com/odoo/odoo/blob/14.0/addons/purchase_stock/report/purchase_report_templates.xml#L11

So it looks like we can remove this unnecessary field `delivery_partner_id`.

cc @alexis-via @rvalyi 