### PR TITLE
[IMP] StockMoves locations domain in picking view

### DIFF
--- a/stock_usability/views/stock_picking.xml
+++ b/stock_usability/views/stock_picking.xml
@@ -34,8 +34,8 @@
         <xpath expr="//field[@name='move_ids_without_package']/tree/field[@name='product_id']" position="after">
             <field name="product_barcode" optional="hide"/>
             <field name="name" optional="hide"/>
-            <field name="location_id" groups="stock.group_stock_multi_locations" optional="show"/>
-            <field name="location_dest_id" groups="stock.group_stock_multi_locations" optional="show"/>
+            <field name="location_id" groups="stock.group_stock_multi_locations" optional="show" domain="[('id', 'child_of', 'parent.location_id')]"  options="{'no_create': True}"/>
+            <field name="location_dest_id" groups="stock.group_stock_multi_locations" optional="show" domain="[('id', 'child_of', 'parent.location_dest_id')]"  options="{'no_create': True}"/>
         </xpath>
         <xpath expr="//field[@name='move_ids_without_package']/tree/button[@name='action_assign_serial']" position="after">
             <button type="object" name="button_do_unreserve" string="Unreserve"
@@ -56,7 +56,7 @@
         </field>
     </field>
 </record>
- 
+
 <record id="view_picking_internal_search" model="ir.ui.view">
     <field name="name">stock_usability.view_picking_search</field>
     <field name="model">stock.picking</field>


### PR DESCRIPTION
Actually the user can define stock.moves with any origin and or destination locations (even "view" type locations !).
It is better to limit it to picking's children locations.

cc @alexis-via @rvalyi 