### PR TITLE
[14.0][ADD] web_tab_title

### DIFF
--- a/web_tab_title/__manifest__.py
+++ b/web_tab_title/__manifest__.py
@@ -1,0 +1,23 @@
+# Copyright 2021 Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'Web Tab Title',
+    'description': """
+        Automatically set tab document.title when empty.
+        Important limitation: the tab will get its title only once you browse it.
+    """,
+    'version': '14.0.1.0.0',
+    'license': 'AGPL-3',
+    'author': 'Akretion',
+    'website': 'akretion.com',
+    'depends': [
+        'web',
+    ],
+    'data': [
+    ],
+    'demo': [
+    ],
+    "data": ["views/web_tab_title.xml"],
+    "maintainers": ["rvalyi"],
+}

--- a/web_tab_title/static/src/js/abstract_web_client.js
+++ b/web_tab_title/static/src/js/abstract_web_client.js
@@ -1,0 +1,29 @@
+/* global vis, py */
+odoo.define("web_tab_title.AbstractWebClient", function (require) {
+    "use strict";
+
+    var AbstractWebClient = require('web.AbstractWebClient');
+
+    var TabTitleAbstractWebClient = AbstractWebClient.include({
+
+        _title_changed: function () {
+            // like the original except we change the title
+            // only when it's different from "Odoo" to avoid
+            // resetting the tab title when switching tabs.
+            var parts = _.sortBy(_.keys(this.get("title_part")), function (x) { return x; });
+            var tmp = "";
+            _.each(parts, function (part) {
+                var str = this.get("title_part")[part];
+                if (str) {
+                    tmp = tmp ? tmp + " - " + str : str;
+                }
+            }, this);
+            if (tmp != "Odoo") {
+                document.title = tmp;
+            }
+        },
+
+    });
+
+    return TabTitleAbstractWebClient;
+});

--- a/web_tab_title/static/src/js/form_controller.js
+++ b/web_tab_title/static/src/js/form_controller.js
@@ -1,0 +1,31 @@
+/* global vis, py */
+odoo.define("web_tab_title.FormController", function (require) {
+    "use strict";
+
+    var FormController = require('web.FormController');
+
+    var TabTitleController = FormController.include({
+
+        on_attach_callback: function () {
+            this._super.apply(this, arguments);
+
+            if (document.title == "Odoo") {
+              var form_name_elem = $("div.oe_title>h1");
+              if (form_name_elem.length == 0) {
+                form_name_elem = $('span.o_field_char[name="name"]')
+              }
+              var title = form_name_elem.text();
+              if (title !== '') {
+                // alternatively we could access the record
+                // in views/basic/basic_model.js
+                // but we would also we miss the model name
+                document.title = title + " - Odoo";
+              }
+            }
+
+        },
+
+    });
+
+    return TabTitleController;
+});

--- a/web_tab_title/views/web_tab_title.xml
+++ b/web_tab_title/views/web_tab_title.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template
+        id="assets_backend"
+        name="web_timeline assets"
+        inherit_id="web.assets_backend"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/web_tab_title/static/src/js/form_controller.js"
+            />
+            <script
+                type="text/javascript"
+                src="/web_tab_title/static/src/js/abstract_web_client.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
When you right click to open records in different tabs, the tab name is "Odoo" which isn't user friendly.

With this module, once the tab is loaded it will dynamically try to set the document.title (tab name) to the form title or to the name field if no title.

It will also prevent Odoo from renaming tabs to "Odoo" when you switch tabs.

Important limitation: **the tab name is set only once you browse the tab!**. I'm not sure if we can do better in general because it seems the form won't be loaded in Odoo until you browse the tab, so we cannot dynamically set the tab name before.

Possible ways would be:

1. set the document.title from the server side, but might be quite a ugly monkey patch of the HTTP layer (of addons/web/controllers/main.py Home#web_client ?)
2. set the document.title from the page source where the right click happens. I'm not even sure if it's possible with right clicks and doing it for all cases may be an important work.