### PR TITLE
purchase_stock_usability: Reception status on PO and PO lines

### DIFF
--- a/purchase_stock_usability/__manifest__.py
+++ b/purchase_stock_usability/__manifest__.py
@@ -23,6 +23,7 @@ Please contact Alexis de Lattre from Akretion <alexis.delattre@akretion.com> for
         'purchase_usability',
         ],
     'data': [
+        'views/purchase_order_views.xml',
         'views/stock_picking.xml',
         ],
     'installable': True,

--- a/purchase_stock_usability/i18n/fr.po
+++ b/purchase_stock_usability/i18n/fr.po
@@ -1,0 +1,111 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* purchase_stock_usability
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-11-02 09:56+0000\n"
+"PO-Revision-Date: 2021-11-02 09:56+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields,field_description:purchase_stock_usability.field_purchase_order__picking_type_id
+msgid "Deliver To"
+msgstr "Livrer à"
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields,field_description:purchase_stock_usability.field_purchase_order__display_name
+#: model:ir.model.fields,field_description:purchase_stock_usability.field_purchase_order_line__display_name
+msgid "Display Name"
+msgstr "Nom affiché"
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields.selection,name:purchase_stock_usability.selection__purchase_order__picking_status__received
+#: model:ir.model.fields.selection,name:purchase_stock_usability.selection__purchase_order_line__move_status__received
+#: model_terms:ir.ui.view,arch_db:purchase_stock_usability.purchase_order_line_search
+#: model_terms:ir.ui.view,arch_db:purchase_stock_usability.purchase_order_view_search
+msgid "Fully Received"
+msgstr "Entièrement reçue"
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields,field_description:purchase_stock_usability.field_purchase_order__id
+#: model:ir.model.fields,field_description:purchase_stock_usability.field_purchase_order_line__id
+msgid "ID"
+msgstr ""
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields,field_description:purchase_stock_usability.field_purchase_order__incoterm_id
+msgid "Incoterm"
+msgstr ""
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields,help:purchase_stock_usability.field_purchase_order__incoterm_id
+msgid ""
+"International Commercial Terms are a series of predefined commercial terms "
+"used in international transactions."
+msgstr ""
+"Les Incoterms sont une série prédéfinie de termes commerciaux utilisés dans "
+"les transactions internationales."
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields,field_description:purchase_stock_usability.field_purchase_order____last_update
+#: model:ir.model.fields,field_description:purchase_stock_usability.field_purchase_order_line____last_update
+msgid "Last Modified on"
+msgstr "Dernière modification le"
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields.selection,name:purchase_stock_usability.selection__purchase_order__picking_status__no
+#: model:ir.model.fields.selection,name:purchase_stock_usability.selection__purchase_order_line__move_status__no
+msgid "Nothing to Receive"
+msgstr "Rien à recevoir"
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields.selection,name:purchase_stock_usability.selection__purchase_order__picking_status__partially_received
+#: model:ir.model.fields.selection,name:purchase_stock_usability.selection__purchase_order_line__move_status__partially_received
+#: model_terms:ir.ui.view,arch_db:purchase_stock_usability.purchase_order_line_search
+#: model_terms:ir.ui.view,arch_db:purchase_stock_usability.purchase_order_view_search
+msgid "Partially Received"
+msgstr "Partiellement reçue"
+
+#. module: purchase_stock_usability
+#: model:ir.model,name:purchase_stock_usability.model_purchase_order
+msgid "Purchase Order"
+msgstr "Commande fournisseur"
+
+#. module: purchase_stock_usability
+#: model:ir.model,name:purchase_stock_usability.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Ligne de commande fournisseur"
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields.selection,name:purchase_stock_usability.selection__purchase_order__picking_status__cancel
+#: model:ir.model.fields.selection,name:purchase_stock_usability.selection__purchase_order_line__move_status__cancel
+msgid "Receipt Cancelled"
+msgstr "Réception annulée"
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields,field_description:purchase_stock_usability.field_purchase_order__picking_status
+#: model:ir.model.fields,field_description:purchase_stock_usability.field_purchase_order_line__move_status
+#: model_terms:ir.ui.view,arch_db:purchase_stock_usability.purchase_order_line_search
+msgid "Reception Status"
+msgstr "État de réception"
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields,help:purchase_stock_usability.field_purchase_order__picking_type_id
+msgid "This will determine operation type of incoming shipment"
+msgstr "Cela déterminera le type d'opération des réceptions"
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields.selection,name:purchase_stock_usability.selection__purchase_order__picking_status__to_receive
+#: model:ir.model.fields.selection,name:purchase_stock_usability.selection__purchase_order_line__move_status__to_receive
+#: model_terms:ir.ui.view,arch_db:purchase_stock_usability.purchase_order_line_search
+#: model_terms:ir.ui.view,arch_db:purchase_stock_usability.purchase_order_view_search
+msgid "To Receive"
+msgstr "À recevoir"

--- a/purchase_stock_usability/i18n/purchase_stock_usability.pot
+++ b/purchase_stock_usability/i18n/purchase_stock_usability.pot
@@ -1,0 +1,109 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* purchase_stock_usability
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-11-02 09:56+0000\n"
+"PO-Revision-Date: 2021-11-02 09:56+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields,field_description:purchase_stock_usability.field_purchase_order__picking_type_id
+msgid "Deliver To"
+msgstr ""
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields,field_description:purchase_stock_usability.field_purchase_order__display_name
+#: model:ir.model.fields,field_description:purchase_stock_usability.field_purchase_order_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields.selection,name:purchase_stock_usability.selection__purchase_order__picking_status__received
+#: model:ir.model.fields.selection,name:purchase_stock_usability.selection__purchase_order_line__move_status__received
+#: model_terms:ir.ui.view,arch_db:purchase_stock_usability.purchase_order_line_search
+#: model_terms:ir.ui.view,arch_db:purchase_stock_usability.purchase_order_view_search
+msgid "Fully Received"
+msgstr ""
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields,field_description:purchase_stock_usability.field_purchase_order__id
+#: model:ir.model.fields,field_description:purchase_stock_usability.field_purchase_order_line__id
+msgid "ID"
+msgstr ""
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields,field_description:purchase_stock_usability.field_purchase_order__incoterm_id
+msgid "Incoterm"
+msgstr ""
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields,help:purchase_stock_usability.field_purchase_order__incoterm_id
+msgid ""
+"International Commercial Terms are a series of predefined commercial terms "
+"used in international transactions."
+msgstr ""
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields,field_description:purchase_stock_usability.field_purchase_order____last_update
+#: model:ir.model.fields,field_description:purchase_stock_usability.field_purchase_order_line____last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields.selection,name:purchase_stock_usability.selection__purchase_order__picking_status__no
+#: model:ir.model.fields.selection,name:purchase_stock_usability.selection__purchase_order_line__move_status__no
+msgid "Nothing to Receive"
+msgstr ""
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields.selection,name:purchase_stock_usability.selection__purchase_order__picking_status__partially_received
+#: model:ir.model.fields.selection,name:purchase_stock_usability.selection__purchase_order_line__move_status__partially_received
+#: model_terms:ir.ui.view,arch_db:purchase_stock_usability.purchase_order_line_search
+#: model_terms:ir.ui.view,arch_db:purchase_stock_usability.purchase_order_view_search
+msgid "Partially Received"
+msgstr ""
+
+#. module: purchase_stock_usability
+#: model:ir.model,name:purchase_stock_usability.model_purchase_order
+msgid "Purchase Order"
+msgstr ""
+
+#. module: purchase_stock_usability
+#: model:ir.model,name:purchase_stock_usability.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr ""
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields.selection,name:purchase_stock_usability.selection__purchase_order__picking_status__cancel
+#: model:ir.model.fields.selection,name:purchase_stock_usability.selection__purchase_order_line__move_status__cancel
+msgid "Receipt Cancelled"
+msgstr ""
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields,field_description:purchase_stock_usability.field_purchase_order__picking_status
+#: model:ir.model.fields,field_description:purchase_stock_usability.field_purchase_order_line__move_status
+#: model_terms:ir.ui.view,arch_db:purchase_stock_usability.purchase_order_line_search
+msgid "Reception Status"
+msgstr ""
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields,help:purchase_stock_usability.field_purchase_order__picking_type_id
+msgid "This will determine operation type of incoming shipment"
+msgstr ""
+
+#. module: purchase_stock_usability
+#: model:ir.model.fields.selection,name:purchase_stock_usability.selection__purchase_order__picking_status__to_receive
+#: model:ir.model.fields.selection,name:purchase_stock_usability.selection__purchase_order_line__move_status__to_receive
+#: model_terms:ir.ui.view,arch_db:purchase_stock_usability.purchase_order_line_search
+#: model_terms:ir.ui.view,arch_db:purchase_stock_usability.purchase_order_view_search
+msgid "To Receive"
+msgstr ""

--- a/purchase_stock_usability/models/purchase.py
+++ b/purchase_stock_usability/models/purchase.py
@@ -6,21 +6,66 @@ from odoo import api, fields, models
 
 
 class PurchaseOrder(models.Model):
-    _inherit = 'purchase.order'
+    _inherit = "purchase.order"
 
     picking_type_id = fields.Many2one(tracking=True)
     incoterm_id = fields.Many2one(tracking=True)
+    picking_status = fields.Selection(
+        [
+            ("received", "Fully Received"),
+            ("partially_received", "Partially Received"),
+            ("to_receive", "To Receive"),
+            ("cancel", "Receipt Cancelled"),
+            ("no", "Nothing to Receive"),
+        ],
+        string="Picking Status",
+        compute="_compute_picking_status",
+        store=True,
+    )
+
+    @api.depends("state", "picking_ids.state")
+    def _compute_picking_status(self):
+        """
+        Compute the picking status for the PO. Possible statuses:
+        - no: if the PO is not in status 'purchase' nor 'done', we consider that
+          there is nothing to receive. This is also the default value if the
+          conditions of no other status is met.
+        - cancel: all pickings are cancelled
+        - received: if all  pickings are done or cancel.
+        - partially_received: If at least one picking is done.
+        - to_receive: if all pickings are in confirmed, assigned, waiting or
+          cancel state.
+        """
+        for order in self:
+            picking_status = "no"
+            if order.state in ("purchase", "done") and order.picking_ids:
+                pstates = [picking.state for picking in order.picking_ids]
+                if all([state == "cancel" for state in pstates]):
+                    picking_status = "cancel"
+                elif all([state in ("done", "cancel") for state in pstates]):
+                    picking_status = "received"
+                elif any([state == "done" for state in pstates]):
+                    picking_status = "partially_received"
+                elif all(
+                    [
+                        state in ("confirmed", "assigned", "waiting", "cancel")
+                        for state in pstates
+                    ]
+                ):
+                    picking_status = "to_receive"
+            order.picking_status = picking_status
 
     # inherit compute method of the field delivery_partner_id
     # defined in purchase_usability
-    @api.depends('dest_address_id', 'picking_type_id')
+    @api.depends("dest_address_id", "picking_type_id")
     def _compute_delivery_partner_id(self):
         for o in self:
             delivery_partner_id = False
             if o.dest_address_id:
                 delivery_partner_id = o.dest_address_id
             elif (
-                    o.picking_type_id.warehouse_id and
-                    o.picking_type_id.warehouse_id.partner_id):
+                o.picking_type_id.warehouse_id
+                and o.picking_type_id.warehouse_id.partner_id
+            ):
                 delivery_partner_id = o.picking_type_id.warehouse_id.partner_id
             o.delivery_partner_id = delivery_partner_id

--- a/purchase_stock_usability/views/purchase_order_views.xml
+++ b/purchase_stock_usability/views/purchase_order_views.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="purchase_order_view_tree" model="ir.ui.view">
+      <field name="name">purchase.order.view.tree (in purchase_stock_usability)</field>
+      <field name="model">purchase.order</field>
+      <field name="inherit_id" ref="purchase.purchase_order_view_tree"/>
+      <field name="arch" type="xml">
+          <xpath expr="//field[@name='invoice_status']" position="after">
+              <field name="picking_status" decoration-success="picking_status == 'received'" decoration-info="picking_status == 'to_receive'" decoration-warning="picking_status == 'partially_received'" decoration-danger="picking_status == 'cancel'" widget="badge" optional="show"/>
+          </xpath>
+      </field>
+    </record>
+
+    <record id="purchase_order_view_search" model="ir.ui.view">
+      <field name="name">purchase.order.select (in purchase_stock_usability)</field>
+      <field name="model">purchase.order</field>
+      <field name="inherit_id" ref="purchase.purchase_order_view_search"/>
+      <field name="arch" type="xml">
+          <xpath expr="//filter[@name='order_date']" position="before">
+              <filter name="received" string="Pickings fully received" domain="[('picking_status', '=', 'received')]"/>
+              <filter name="partially_received" string="Pickings partially received" domain="[('picking_status', '=', 'partially_received')]"/>
+              <filter name="to_receive" string="Pickings to receive" domain="[('picking_status', '=', 'to_receive')]"/>
+              <separator/>
+          </xpath>
+      </field>
+    </record>
+
+    <record id="purchase_order_line_tree" model="ir.ui.view">
+      <field name="name">purchase.order.line.view.tree (in purchase_stock_usability)</field>
+      <field name="model">purchase.order.line</field>
+      <field name="inherit_id" ref="purchase.purchase_order_line_tree"/>
+      <field name="arch" type="xml">
+          <xpath expr="//tree" position="inside">
+              <field name="move_status" decoration-success="move_status == 'received'" decoration-info="move_status == 'to_receive'" decoration-warning="move_status == 'partially_received'" decoration-danger="move_status == 'cancel'" widget="badge" optional="show"/>
+          </xpath>
+      </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Some clients may want to follow the Reception status at PO line level in addition to PO level. So I moved the status computation to the purchase.order.line model.
It does not change the previous behavior, just add the possibility to display this Reception Status on PO line tree or PO tree.

cc @rvalyi @alexis-via 