### PR TITLE
[FIX] account_usability : Add bank journal without statements source …

### DIFF
--- a/account_usability/models/account_move.py
+++ b/account_usability/models/account_move.py
@@ -175,7 +175,8 @@ class AccountMove(models.Model):
                         [('company_id', '=', company_id)],
                         expression.OR([
                             [('type', 'in', ('general', 'cash'))],
-                            [('type', '=', 'bank'), ('bank_account_id', '=', False)]
+                            [('type', '=', 'bank'), ('bank_account_id', '=', False)],
+                            [('type', '=', 'bank'), ('bank_statements_source', '=', 'undefined')],
                             ])
                         ])
                 move.suitable_journal_ids = self.env['account.journal'].search(domain)


### PR DESCRIPTION
…for create account move

Currently only cash journal and bank journal without an banck account were added in order to be able to create accounting move. So I added the possibility of also having the bank journals which do not have statements source.