### PR TITLE
14.0 improve matching number and fix filter, improve account move line filter

### DIFF
--- a/account_usability/__init__.py
+++ b/account_usability/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import wizard
+from .hooks import post_init_hook

--- a/account_usability/__manifest__.py
+++ b/account_usability/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Account Usability',
-    'version': '14.0.1.0.0',
+    'version': '14.0.1.1.0',
     'category': 'Accounting & Finance',
     'license': 'AGPL-3',
     'summary': 'Small usability enhancements in account module',
@@ -41,4 +41,5 @@
         ],
     'qweb': ['static/src/xml/account_payment.xml'],
     'installable': True,
+    "post_init_hook": "post_init_hook",
 }

--- a/account_usability/hooks.py
+++ b/account_usability/hooks.py
@@ -1,0 +1,9 @@
+# Copyright 2022 Akretion (https://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import SUPERUSER_ID, api
+
+def post_init_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env["account.move.line"].update_matching_number()

--- a/account_usability/i18n/account_usability.pot
+++ b/account_usability/i18n/account_usability.pot
@@ -525,11 +525,6 @@ msgid "Recipient Bank"
 msgstr ""
 
 #. module: account_usability
-#: model:ir.model.fields,field_description:account_usability.field_account_move_line__reconcile_string
-msgid "Reconcile"
-msgstr ""
-
-#. module: account_usability
 #: model:ir.model.fields,field_description:account_usability.field_account_bank_statement_line__ref
 #: model:ir.model.fields,field_description:account_usability.field_account_move__ref
 #: model:ir.model.fields,field_description:account_usability.field_account_payment__ref

--- a/account_usability/migrations/14.0.1.1.0/post-migrate.py
+++ b/account_usability/migrations/14.0.1.1.0/post-migrate.py
@@ -1,0 +1,9 @@
+# Copyright 2020 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env["account.move.line"].update_matching_number()

--- a/account_usability/models/account_move.py
+++ b/account_usability/models/account_move.py
@@ -2,12 +2,15 @@
 # @author Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import logging
 from odoo import api, fields, models, _
 from odoo.tools import float_is_zero
 from odoo.tools.misc import format_date
 from odoo.osv import expression
 from datetime import timedelta
 from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
 
 
 class AccountMove(models.Model):
@@ -238,8 +241,6 @@ class AccountMoveLine(models.Model):
     full_reconcile_id = fields.Many2one(string='Full Reconcile')
     matched_debit_ids = fields.One2many(string='Partial Reconcile Debit')
     matched_credit_ids = fields.One2many(string='Partial Reconcile Credit')
-    reconcile_string = fields.Char(
-        compute='_compute_reconcile_string', string='Reconcile', store=True)
     # for optional display in tree view
     product_barcode = fields.Char(related='product_id.barcode', string="Product Barcode")
 
@@ -255,17 +256,21 @@ class AccountMoveLine(models.Model):
         })
         return action
 
-    @api.depends(
-            'full_reconcile_id', 'matched_debit_ids', 'matched_credit_ids')
-    def _compute_reconcile_string(self):
-        for line in self:
-            rec_str = False
-            if line.full_reconcile_id:
-                rec_str = line.full_reconcile_id.name
-            else:
-                rec_str = ', '.join([
-                    'a%d' % pr.id for pr in line.matched_debit_ids + line.matched_credit_ids])
-            line.reconcile_string = rec_str
+    def update_matching_number(self):
+        records = self.search([("matching_number", "=", "P")])
+        _logger.info(f"Update partial reconcile number for {len(records)} lines")
+        records._compute_matching_number()
+
+    def _compute_matching_number(self):
+        # TODO maybe it will be better to have the same maching_number for
+        # all partial so it will be easier to group by
+        super()._compute_matching_number()
+        for record in self:
+            if record.matching_number == "P":
+                record.matching_number = ", ".join([
+                    "a%d" % pr.id
+                    for pr in record.matched_debit_ids + record.matched_credit_ids
+                ])
 
     def _get_computed_name(self):
         # This is useful when you want to have the product code in a dedicated

--- a/account_usability/views/account_move.xml
+++ b/account_usability/views/account_move.xml
@@ -42,8 +42,7 @@
             <attribute name="optional">show</attribute>
         </xpath>
         <xpath expr="//field[@name='line_ids']/tree/field[@name='tax_tag_ids']" position="after">
-            <field name="matching_number" optional="hide"/>
-            <field name="reconcile_string" optional="show"/>
+            <field name="matching_number" optional="show"/>
         </xpath>
         <xpath expr="//field[@name='invoice_line_ids']/tree/field[@name='product_id']" position="after">
             <field name="product_barcode" optional="hide"/>
@@ -106,7 +105,7 @@
             <separator/>
         </filter>
         <field name="partner_id" position="after">
-            <field name="reconcile_string" />
+            <field name="matching_number" />
             <field name="debit" filter_domain="['|', ('debit', '=', self), ('credit', '=', self)]" string="Debit or Credit"/>
         </field>
         <filter name="unreconciled" position="before">

--- a/account_usability/views/account_move.xml
+++ b/account_usability/views/account_move.xml
@@ -117,6 +117,9 @@
         <field name="name" position="attributes">
             <attribute name="string">Label, Reference, Account or Partner</attribute>
         </field>
+        <field name="name" position="before">
+            <field name="move_id" position="move"/>
+        </field>
         <field name="partner_id" position="attributes">
             <attribute name="domain">['|', ('parent_id', '=', False), ('is_company', '=', True)]</attribute>
         </field>


### PR DESCRIPTION
@alexis-via 
J'ai mis un TODO, je me demande si à terme ça serait pas mieux d'avoir un code de lettrage partielle uniquement au lieu d'avoir une liste.

Par exemple j'ai un paiement de 1200€ je lettre une facture de 500 et de 400, ça peux etre bien d'avoir sur les 3 écritures le meme numéro (aXXX) au lieu de aXXX, aYYY, a voir si ça vaut le cout car pas si simple que ça à implémenté