### PR TITLE
eradicate_quickreate: fix hook

### DIFF
--- a/eradicate_quick_create/hooks.py
+++ b/eradicate_quick_create/hooks.py
@@ -10,7 +10,7 @@ def web_m2x_options_create(cr, registry):
     env = Environment(cr, SUPERUSER_ID, {})
     config_parameter = env['ir.config_parameter'].search(
         [('key', '=', 'web_m2x_options.create')])
-    if config_parameter and config_parameter.value != 'False':
+    if config_parameter:
         config_parameter.write({'value': 'False'})
     else:
         env['ir.config_parameter'].create({


### PR DESCRIPTION
if the record already exists and is False, we shouldn't create a new record

