### PR TITLE
[14.0][FIX] account_invoice_update_wizard_payment_mode view dependency

### DIFF
--- a/account_invoice_update_wizard_payment_mode/wizard/account_move_update_view.xml
+++ b/account_invoice_update_wizard_payment_mode/wizard/account_move_update_view.xml
@@ -12,7 +12,7 @@
     <field name="model">account.move.update</field>
     <field name="inherit_id" ref="account_invoice_update_wizard.account_invoice_update_form"/>
     <field name="arch" type="xml">
-        <field name="invoice_payment_term_id" position="after">
+        <field name="partner_bank_id" position="before">
             <field name="payment_mode_filter_type_domain" invisible="1"/>
             <field name="partner_bank_filter_type_domain" invisible="1"/>
             <field name="bank_account_required" invisible="1"/>


### PR DESCRIPTION
field `invoice_payment_term_id` was removed by https://github.com/akretion/odoo-usability/commit/9c7775dabb6c14471dcbd3c0b475f442a690255d#

needs to be removed from account_invoice_update_wizard_payment_mode's view
@sebastienbeau @alexis-via 
cc @rvalyi 