### PR TITLE
14.0 remove duplicated button

### DIFF
--- a/sale_usability/i18n/fr.po
+++ b/sale_usability/i18n/fr.po
@@ -400,11 +400,6 @@ msgstr ""
 "exception avec le message et bloquera le flux. Le message doit être écrit dans le champ suivant."
 
 #. module: sale_usability
-#: model_terms:ir.ui.view,arch_db:sale_usability.view_order_form
-msgid "Send Order Acknowledgement"
-msgstr "Confirmation de commande"
-
-#. module: sale_usability
 #: model_terms:ir.ui.view,arch_db:sale_usability.view_sales_order_filter
 msgid "State"
 msgstr "État"

--- a/sale_usability/views/sale_order.xml
+++ b/sale_usability/views/sale_order.xml
@@ -32,9 +32,6 @@
         <xpath expr="//field[@name='order_line']/tree/field[@name='product_template_id']" position="after">
             <field name="product_barcode" optional="hide"/>
         </xpath>
-        <button name="action_quotation_send" attrs="{'invisible': ['|', ('state', '=', 'draft'), ('invoice_count','&gt;=',1)]}" position="before">
-            <button name="action_quotation_send" type="object" string="Send Order Acknowledgement" attrs="{'invisible': ['|', ('state', 'not in', ('sale', 'done')), ('invoice_count','&gt;=',1)]}"/>
-        </button>
     </field>
 </record>
 


### PR DESCRIPTION
In odoo V14 : https://github.com/odoo/odoo/blob/f766a573e1efaf6e0b91c419a000449ae4d3e014/addons/sale/views/sale_views.xml#L289
We already have a button for sending the order by email when the so is in state done or sale

Usability module add a new button that do exactly the same thing with a different name

![image](https://user-images.githubusercontent.com/1164578/229766059-d552df39-71c7-4089-896f-493ec354342f.png)

So we should remove it or have a different behaviour
