### PR TITLE
[FIX] 14.0 sale-usability - Avoid useless recompute on sale_ids

### DIFF
--- a/sale_usability/models/account_move.py
+++ b/sale_usability/models/account_move.py
@@ -11,9 +11,9 @@ class AccountMove(models.Model):
 
     # sale_ids is kind of the symetric field of invoice_ids on sale.order
     sale_ids = fields.Many2many(
-        'sale.order', string='Sale Orders', compute="_compute_sale_ids")
+        'sale.order', string='Sale Orders', compute="_compute_sale_ids", store=True)
     sale_count = fields.Integer(
-        string='Sale Order Count', compute='_compute_sale_ids')
+        string='Sale Order Count', compute="_compute_sale_ids", store=True)
 
     @api.depends('invoice_line_ids.sale_line_ids')
     def _compute_sale_ids(self):


### PR DESCRIPTION
Before: I had unwanted recomputes when creating a sale.order. The compute loop over the set of account.move !
After: Compute seems to work only when needed