### PR TITLE
Revert "account_usability: reset to draft the bank statement do not unreconcile items

### DIFF
--- a/account_usability/models/account_bank_statement.py
+++ b/account_usability/models/account_bank_statement.py
@@ -43,13 +43,6 @@ class AccountBankStatement(models.Model):
             res.append((statement.id, name))
         return res
 
-    def button_reopen(self):
-        self = self.with_context(skip_undo_reconciliation=True)
-        return super().button_reopen()
-
-    def button_undo_reconciliation(self):
-        self.line_ids.button_undo_reconciliation()
-
 
 class AccountBankStatementLine(models.Model):
     _inherit = 'account.bank.statement.line'
@@ -96,9 +89,3 @@ class AccountBankStatementLine(models.Model):
             'res_id': self.move_id.id,
             })
         return action
-
-    def button_undo_reconciliation(self):
-        if self._context.get("skip_undo_reconciliation"):
-            return
-        else:
-            return super().button_undo_reconciliation()

--- a/account_usability/views/account_bank_statement.xml
+++ b/account_usability/views/account_bank_statement.xml
@@ -16,14 +16,6 @@
         <button name="button_reopen" position="attributes">
             <attribute name="confirm">Are you sure ? Don't do 'Reset to New' if you just want to modify the bank journal entry of an existing statement line.</attribute>
         </button>
-        <button name="button_reopen" position="after">
-            <button
-                name="button_undo_reconciliation"
-                type="object"
-                confirm="Are you sure to unreconcile all the entries of the bank statement?"
-                states="open"
-                string="Unreconcile All"/>
-        </button>
         <xpath expr="//field[@name='line_ids']/tree/button[@name='button_undo_reconciliation']" position="after">
             <field name="move_id" invisible="1"/>
             <button name="show_account_move" type="object"


### PR DESCRIPTION
Revert https://github.com/akretion/odoo-usability/pull/174
There is an unresolved issue on the subject : https://github.com/akretion/odoo-usability/issues/191

Today when we click on the reset to draft button, all reconciliation are removed, but the bank statement line is still considered as done/reconciled.
It is very, very error prone and if you want then add the reconciliation back, you have to revert the reconciliation line anyway...
I can't see how it is usable, and it is very error prone.

The reconciliation are removed because all bank statement accounting entries are reseted to draft. If we want to keep this functionality, we'd have to check if it is possible/reasonable to have draft account move lines reconciled, or if we can do a "reset to draft" but keeping the statement accounting entries as posted.

I am not sure what was the initial goals, but if it is to be able to add a line or change a line, I guess we'd better to just allow changes in a posted bank statement...

Please, let's merge this PR soon, and if you really want to continue with it, do it in a separated module...

@sebastienbeau @alexis-via @bguillot 