### PR TITLE
[IMP] account_invoice_update_wizard : Adapt wizard view and button to make it usable on accountring entries + small improvements

### DIFF
--- a/account_invoice_update_wizard/views/account_move.xml
+++ b/account_invoice_update_wizard/views/account_move.xml
@@ -11,7 +11,8 @@
     <field name="inherit_id" ref="account.view_move_form"/>
     <field name="arch" type="xml">
         <button name="button_draft" position="before">
-            <button name="prepare_update_wizard" type="object" string="Update Invoice" states="posted" groups="account.group_account_invoice"/>
+            <button name="prepare_update_wizard" type="object" string="Update Invoice" groups="account.group_account_invoice" attrs="{'invisible': ['|', ('state', '!=', 'posted'), ('move_type', '=', 'entry')]}"/>
+            <button name="prepare_update_wizard" type="object" string="Update Entry" groups="account.group_account_invoice" attrs="{'invisible': ['|', ('state', '!=', 'posted'), ('move_type', '!=', 'entry')]}"/>
         </button>
     </field>
 </record>

--- a/account_invoice_update_wizard/wizard/account_move_update.py
+++ b/account_invoice_update_wizard/wizard/account_move_update.py
@@ -21,6 +21,7 @@ class AccountMoveUpdate(models.TransientModel):
     invoice_payment_term_id = fields.Many2one(
         'account.payment.term', string='Payment Term')
     ref = fields.Char(string='Reference')  # field label is customized in the view
+    invoice_date = fields.Date()
     invoice_origin = fields.Char(string='Source Document')
     partner_bank_id = fields.Many2one(
         'res.partner.bank', string='Bank Account')
@@ -30,7 +31,7 @@ class AccountMoveUpdate(models.TransientModel):
     @api.model
     def _simple_fields2update(self):
         '''List boolean, date, datetime, char, text fields'''
-        return ['ref', 'invoice_origin']
+        return ['ref', 'invoice_origin', 'invoice_date']
 
     @api.model
     def _m2o_fields2update(self):

--- a/account_invoice_update_wizard/wizard/account_move_update_view.xml
+++ b/account_invoice_update_wizard/wizard/account_move_update_view.xml
@@ -17,11 +17,12 @@
                     <field name="partner_id" invisible="1"/>
                     <field string="Bill Reference" attrs="{'invisible': [('move_type', 'not in', ('in_invoice', 'in_refund'))]}" name="ref"/>
                     <field string="Customer Reference" attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund'))]}" name="ref"/>
-                    <field name="invoice_origin"/>
+                    <field string="Ref" attrs="{'invisible': [('move_type', '!=', 'entry')]}" name="ref"/>
+                    <field name="invoice_origin" attrs="{'invisible': [('move_type', '=', 'entry')]}"/>
                     <!-- update of payment term is broken -->
                     <!-- <field name="invoice_payment_term_id" widget="selection"/>-->
-                    <field name="partner_bank_id"/>
-                    <field name="user_id" options="{'no_open': True, 'no_create': True, 'no_create_edit': True}"/>
+                    <field name="partner_bank_id" attrs="{'invisible': [('move_type', '=', 'entry')]}"/>
+                    <field name="user_id" options="{'no_open': True, 'no_create': True, 'no_create_edit': True}" attrs="{'invisible': [('move_type', '=', 'entry')]}"/>
                 </group>
                 <group name="lines">
                     <field name="line_ids" nolabel="1" widget="section_and_note_one2many">
@@ -30,8 +31,8 @@
                             <field name="display_type" invisible="1"/>
                             <field name="currency_id" invisible="1"/>
                             <field name="name"/>
-                            <field name="quantity" attrs="{'invisible': [('display_type', '!=', False)]}"/>
-                            <field name="price_subtotal" attrs="{'invisible': [('display_type', '!=', False)]}"/>
+                            <field name="quantity" attrs="{'invisible': [('display_type', '!=', False)], 'column_invisible': [('parent.move_type', '=', 'entry')]}"/>
+                            <field name="price_subtotal" attrs="{'invisible': [('display_type', '!=', False)], 'column_invisible': [('parent.move_type', '=', 'entry')]}"/>
                             <field name="analytic_account_id" attrs="{'invisible': [('display_type', '!=', False)]}" groups="analytic.group_analytic_accounting"/>
                             <field name="analytic_tag_ids" attrs="{'invisible': [('display_type', '!=', False)]}" groups="analytic.group_analytic_tags" widget="many2many_tags"/>
                     </tree>

--- a/account_invoice_update_wizard/wizard/account_move_update_view.xml
+++ b/account_invoice_update_wizard/wizard/account_move_update_view.xml
@@ -15,7 +15,8 @@
                     <field name="move_type" invisible="1"/>
                     <field name="company_id" invisible="1"/>
                     <field name="partner_id" invisible="1"/>
-                    <field string="Bill Reference" attrs="{'invisible': [('move_type', 'not in', ('in_invoice', 'in_refund'))]}" name="ref"/>
+                    <field string="Bill Date" attrs="{'invisible': [('move_type', 'not in', ('in_invoice', 'in_refund'))]}" name="invoice_date"/>
+                    <field string="Supplier Bill Reference" attrs="{'invisible': [('move_type', 'not in', ('in_invoice', 'in_refund'))]}" name="ref"/>
                     <field string="Customer Reference" attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund'))]}" name="ref"/>
                     <field string="Ref" attrs="{'invisible': [('move_type', '!=', 'entry')]}" name="ref"/>
                     <field name="invoice_origin" attrs="{'invisible': [('move_type', '=', 'entry')]}"/>


### PR DESCRIPTION
The goal is mainly to update an analytic account on a accountring entry.

Use case : Set a default analytic account on automatic entries like currency rate exchange. 
Use this module to be able to change the analytic account depending on your real need. (this currency rate exchange entry is not even allowed to be set to draft)

Also : 
- Rename bill reference to invoice bill reference, to have a consitent name in wizard with the name of the field on invoice
- Add possibility to change invoice date (only for supplier invoices/refunds)


@alexis-via 