### PR TITLE
[MIG] sale_no_optional_product

### DIFF
--- a/sale_no_optional_product/__manifest__.py
+++ b/sale_no_optional_product/__manifest__.py
@@ -11,7 +11,7 @@
     "author": " Akretion",
     "license": "AGPL-3",
     "application": False,
-    "installable": False,
+    "installable": True,
     "external_dependencies": {
         "python": [],
         "bin": [],


### PR DESCRIPTION
module works out of the box in 16.0