### PR TITLE
FIX: Remove invalidate display name from the post install script

### DIFF
--- a/base_partner_ref/post_install.py
+++ b/base_partner_ref/post_install.py
@@ -9,4 +9,4 @@ def update_partner_display_name(cr, registry):
     env = api.Environment(cr, SUPERUSER_ID, {})
     partners = env['res.partner'].with_context(active_test=False).search(
         [('ref', '!=', False)])
-    partners.write({'invalidate_display_name': True})
+    partners._compute_display_name()


### PR DESCRIPTION
The field  has been removed by https://github.com/akretion/odoo-usability/commit/0aa31956e0b17d40c09dd5e634a626c412c8eb5f

This Commit adapt the post install script consequently