### PR TITLE
[16.0][IMP] base_usability: Replace company name fetching from parent_id to commercial_partner_id

### DIFF
--- a/base_usability/models/res_partner.py
+++ b/base_usability/models/res_partner.py
@@ -54,8 +54,12 @@ class ResPartner(models.Model):
             title = False
             title_short = False
         else:
-            company = self.parent_id and self.parent_id.is_company and\
-                self.parent_id.name or False
+            company = (
+                self.commercial_partner_id
+                and self.commercial_partner_id.is_company
+                and self.commercial_partner_id.name
+                or False
+            )
             name = self.name_title
             name_no_title = self.name
             title = self.title.name


### PR DESCRIPTION
Some company partners might not be directly related to their company, but have an intermidiary partner. As such, fetching only the parent partner and checking whether they're a company is not sufficiant.

As such, we replace the parent_id field by the commercial_partner_id field, which fetches either the parent, if they're a company, or the grandparent of any given partner.

Since we can deal with cases where the grand-parent is not a company, we still check the 'is_company' field.