### PR TITLE
[16.0][IMP] base_mail_sender_bcc: avoid intempestive BCC

### DIFF
--- a/base_mail_sender_bcc/__manifest__.py
+++ b/base_mail_sender_bcc/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Mail Sender Bcc',
-    'version': '16.0.1.0.0',
+    'version': '16.0.1.0.3',
     'category': 'Mail',
     'license': 'AGPL-3',
     'summary': "Always send a copy of the mail to the sender",
@@ -13,9 +13,23 @@ Mail Sender Bcc
 ===============
 
 With this module, when Odoo sends an outgoing email, it adds the sender as Bcc (blind copy) of the email.
+
+Examples:
+
+* When a users sends invoice overdue reminders
+* When a users sends a Customer Invoice or a Purchase Order
+
+For some other use-cases willingly opt-out, the sender will not be added in Bcc:
+
+* User action triggering fields-tracking message (e.g. validation of a HR Timesheet Sheet)
+* Python-submitted message, such as import reports
+* Re-routing an inbound email to followers
+* message submitted in the chatter to internal users (with an accepted defect: if there is 1 external partner
+  within an email mixing both external partners and internal users in recipients, the sender will be added in
+  Bcc anyway)
     """,
     'author': 'Akretion',
     'website': 'https://github.com/akretion/odoo-usability',
-    'depends': ['base'],
+    'depends': ['mail'],
     'installable': True,
 }

--- a/base_mail_sender_bcc/models/__init__.py
+++ b/base_mail_sender_bcc/models/__init__.py
@@ -1,1 +1,2 @@
 from . import ir_mail_server
+from . import mail_thread

--- a/base_mail_sender_bcc/models/ir_mail_server.py
+++ b/base_mail_sender_bcc/models/ir_mail_server.py
@@ -4,34 +4,49 @@
 
 from odoo import models, tools
 
-
 class IrMailServer(models.Model):
     _inherit = 'ir.mail_server'
 
     def build_email(
-            self, email_from, email_to, subject, body, email_cc=None,
-            email_bcc=None, reply_to=False, attachments=None,
-            message_id=None, references=None, object_id=False,
-            subtype='plain', headers=None,
-            body_alternative=None, subtype_alternative='plain'):
-        if email_from:
+        self, email_from, email_to, subject, body, email_cc=None,
+        email_bcc=None, **kwargs
+    ):
+        """Add `email_from` in BCC right before sending the email, if:
+         * Not prevented by context key `prevent_send_mail_bcc`
+         * The `email_from` is an Odoo internal user. Else we might add in BCC
+           and external partner when re-routing incoming emails to internal
+           users who choosed `notification_type=email` in their preferences
+        """
+        should_bcc = email_from and not self._context.get("prevent_send_mail_bcc")
+        if should_bcc:
+            email_from_normalized = tools.email_normalize_all(email_from)
+            user_from = self.env["res.users"].search(
+                domain=[("email", "=", email_from_normalized)],
+                limit=1,
+            )
+            should_bcc = bool(user_from) and user_from._is_internal()
+
+        if should_bcc:
             if email_bcc is None:
                 email_bcc = [email_from]
             elif isinstance(email_bcc, list) and email_from not in email_bcc:
                 email_bcc.append(email_from)
+        
         return super().build_email(
             email_from, email_to, subject, body, email_cc=email_cc,
-            email_bcc=email_bcc, reply_to=reply_to, attachments=attachments,
-            message_id=message_id, references=references, object_id=object_id,
-            subtype=subtype, headers=headers,
-            body_alternative=body_alternative, subtype_alternative=subtype_alternative)
+            email_bcc=email_bcc, **kwargs
+        )
 
     def _prepare_email_message(self, message, smtp_session):
-        validated_to = self.env.context.get('send_validated_to') or []
+        """Update context key `send_validated_to` with the possible
+        added BCC email addresses"""
         if message['Bcc']:
+            validated_to = self.env.context.get('send_validated_to') or []
             email_bcc_normalized = tools.email_normalize_all(message['Bcc'])
             for email in email_bcc_normalized:
                 if email not in validated_to:
                     validated_to.append(email)
-        return super(IrMailServer, self.with_context(send_validated_to=validated_to))._prepare_email_message(
-            message, smtp_session)
+            self = self.with_context(send_validated_to=validated_to)
+        return super()._prepare_email_message(
+            message, smtp_session
+        )

--- a/base_mail_sender_bcc/models/mail_thread.py
+++ b/base_mail_sender_bcc/models/mail_thread.py
@@ -1,0 +1,29 @@
+# Copyright 2024 Akretion (https://www.akretion.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class MailThread(models.AbstractModel):
+    _inherit = "mail.thread"
+
+    def _notify_thread_by_email(self, message, recipients_data, msg_vals=False, **kwargs):
+        """Prevent BCC for/when:
+        1) Odoo-generated notifications (`message_type=notification`). Examples:
+            * changelog-messages of fields with `tracking=True`
+            * Python-submitted message, such as import reports
+        2) Internal users notified by email because of their profile preference
+           (`notification_type=email`).
+              (!) This is not perfect: If any external partner is among the recipients,
+              BCC applies normally. Internal Users will be BCC-ed as soon as at least
+              1 external partner is in the recipients.
+        """
+        should_bcc = (
+            message.message_type == "notification" or
+            recipients_data and all(r.get("type") == "user" for r in recipients_data)
+        )
+        if should_bcc:
+            self = self.with_context(prevent_send_mail_bcc=True)
+        return super()._notify_thread_by_email(
+            message, recipients_data, msg_vals=msg_vals, **kwargs
+        )


### PR DESCRIPTION
Intempestive BCC like:
* When a user send its timesheet.sheet to manager's approval, the notification triggers an email to all the managers who choseed "Receive notification in email" (and not in Odoo). The user who just validated its timesheet was added in BCC of the "notification" mail
* When an external partner (e.g. customer or supplier) responds to an email sent by Odoo (e.g. a purchase request), the email is processed by Odoo and sent back to the followers of the Purchase Request. In this "re-routed" email, the "from" address, meaning the supplier, is added in BCC of the re-routed mails.

=> This PR proposes to only add Odoo users in BCC for the email sent by the mail.compose.wizard.