### PR TITLE
[18.0][FIX] account_reconcile_oca_usability_akretion: add missing dependency on account_usability_akretion

### DIFF
--- a/account_reconcile_oca_usability_akretion/__manifest__.py
+++ b/account_reconcile_oca_usability_akretion/__manifest__.py
@@ -10,7 +10,7 @@
     'summary': 'Small usability enhancements in OCA bank reconcile interface',
     'author': 'Akretion',
     'website': 'https://github.com/akretion/odoo-usability',
-    'depends': ['account_reconcile_oca'],
+    'depends': ['account_reconcile_oca', 'account_usability_akretion'],
     'data': [],
     "assets": {
         "web.assets_backend": [


### PR DESCRIPTION
Fixes #250.

`account_reconcile_oca_usability_akretion` patches the OCA reconcile controller and reads two
fields on `account.journal`:

```js
// static/src/js/reconcile_controller_patch.esm.js, lines 20 and 23
["bank_default_account_balance", "bank_currency_id"],
this.state.journalBalance = read_res[0].bank_default_account_balance;
```

Both are declared in `account_usability_akretion/models/account_journal.py`, which was not listed
as a dependency — the manifest only declared `account_reconcile_oca`.

Installing the module on its own therefore breaks the journal screen:

```
ValueError: Invalid field 'bank_default_account_balance' on model 'account.journal'
```

Nothing fails at install or load time; the error only surfaces when a user opens the journal or
reconciliation screen, so it is easy to ship unnoticed. Encountered on a live Odoo 18 database.

This adds the missing dependency.
