### PR TITLE
[18.0][FIX] base_usability_akretion: fix message["From"] handling

### DIFF
--- a/base_usability_akretion/models/ir_mail_server.py
+++ b/base_usability_akretion/models/ir_mail_server.py
@@ -26,16 +26,25 @@ class IrMailServer(models.Model):
                 smtp_debug=smtp_debug, mail_server_id=mail_server_id)
         # _prepare_email_message() will remove the Bcc field in message
         # that's why we need to save it and re-inject it in message
+        # The From field can also be altered, therefore in order for
+        # _prepare_email_message to be idempotent (it will be called again 
+        # in super().send_email(..) ) we save it and put it back if needed.
         email_bcc = message['Bcc']
+        email_from_orig = message['From']
         smtp_from, smtp_to_list, message = self._prepare_email_message(
             message, smtp_session)
         message['Bcc'] = email_bcc
         # End copy from native method
         logger.info(
             "Sending email from '%s' to '%s' Cc '%s' Bcc '%s' "
-            "with subject '%s'. smtp_to_list=%s",
-            smtp_from, message.get('To'), message.get('Cc'),
-            message.get('Bcc'), message.get('Subject'), smtp_to_list)
+            "with subject '%s'. smtp_from=%s smtp_to_list=%s",
+            message.get('From'), message.get('To'), message.get('Cc'),
+            message.get('Bcc'), message.get('Subject'), smtp_from, smtp_to_list)
+        
+        if  message['From'] != email_from_orig:
+            del message['From']
+            message['From'] = email_from_orig
+
         return super().send_email(
             message, mail_server_id=mail_server_id,
             smtp_server=smtp_server, smtp_port=smtp_port,


### PR DESCRIPTION
This fix adresses 2 issues :

1/ when logging the sending of the email, message["From"] should be used to display the From field, as smtp_from can be something else, which will be used as the Return-path, and because of that, we should also display the smtp_from value

2/ in relation to the above we should keep intact the original message["From"] in order to have _prepare_email_message being idempotent as it can change it, see https://github.com/odoo/odoo/blob/d5d4c30506d0268daafb527e188aa0982fd4a721/odoo/addons/base/models/ir_mail_server.py#L685

