### PR TITLE
[FIX] base_usability_akretion: avoid double mail preparation losing From name

### DIFF
--- a/base_usability_akretion/models/ir_mail_server.py
+++ b/base_usability_akretion/models/ir_mail_server.py
@@ -17,29 +17,25 @@ class IrMailServer(models.Model):
             smtp_user=None, smtp_password=None, smtp_encryption=None,
             smtp_ssl_certificate=None, smtp_ssl_private_key=None,
             smtp_debug=False, smtp_session=None):
-        # Start copy from native method
-        if not smtp_session:
-            smtp_session = self.connect(
-                smtp_server, smtp_port, smtp_user, smtp_password, smtp_encryption,
-                smtp_from=message['From'], ssl_certificate=smtp_ssl_certificate,
-                ssl_private_key=smtp_ssl_private_key,
-                smtp_debug=smtp_debug, mail_server_id=mail_server_id)
-        # _prepare_email_message() will remove the Bcc field in message
-        # that's why we need to save it and re-inject it in message
+        # _prepare_email_message() removes the Bcc header from the message
+        # (recipients are still delivered via the SMTP envelope): keep it
+        # to log it.
         email_bcc = message['Bcc']
-        smtp_from, smtp_to_list, message = self._prepare_email_message(
-            message, smtp_session)
-        message['Bcc'] = email_bcc
-        # End copy from native method
-        logger.info(
-            "Sending email from '%s' to '%s' Cc '%s' Bcc '%s' "
-            "with subject '%s'. smtp_to_list=%s",
-            smtp_from, message.get('To'), message.get('Cc'),
-            message.get('Bcc'), message.get('Subject'), smtp_to_list)
-        return super().send_email(
+        # Let the native method do the whole connect/prepare/send. Preparing
+        # the message here and passing it + the session to super() triggers a
+        # SECOND _prepare_email_message() in the native method, which drops
+        # the author display name added by the From encapsulation logic
+        # (encapsulate_email) introduced in Odoo 18.
+        res = super().send_email(
             message, mail_server_id=mail_server_id,
             smtp_server=smtp_server, smtp_port=smtp_port,
             smtp_user=smtp_user, smtp_password=smtp_password,
             smtp_encryption=smtp_encryption, smtp_ssl_certificate=smtp_ssl_certificate,
             smtp_ssl_private_key=smtp_ssl_private_key, smtp_debug=smtp_debug,
             smtp_session=smtp_session)
+        logger.info(
+            "Sending email from '%s' to '%s' Cc '%s' Bcc '%s' "
+            "with subject '%s'.",
+            message.get('From'), message.get('To'), message.get('Cc'),
+            email_bcc, message.get('Subject'))
+        return res


### PR DESCRIPTION
The bug : 
In native Odoo if you got a generic mail to send the message (contact@mycompany.com), and I send a mail with my user (Florian da Costa), the FROM will become Florian da Costa <contact@mycompany.com>
Currently because of base_usability_akretion, the FROM will simply be contact@mycompany.com

The problem with current code is that _prepare_email_message is called twice, once before call to super and then during the super call.
On the first call condition here is met : https://github.com/OCA/OCB/blob/18.0/odoo/addons/base/models/ir_mail_server.py#L682
On the second, it is not anymore so the FROM is erased here : https://github.com/OCA/OCB/blob/18.0/odoo/addons/base/models/ir_mail_server.py#L685

Anyway, from my understanding, the only goal is to log stuff, and this refactore does it with less impact
What do you think @alexis-via 